### PR TITLE
update conditional compilation to support Apple `clang`

### DIFF
--- a/include/wll_interface.h
+++ b/include/wll_interface.h
@@ -28,15 +28,12 @@ namespace wll
 {
 
 
-#if defined(__GNUC__)
-static_assert(__GNUC__ >= 7);
+#if defined(__GNUC__) || defined(__clang__)
+static_assert(__GNUC__ >= 7 || __clang_major__ >= 4);
 #define WLL_CURRENT_FUNCTION std::string(__PRETTY_FUNCTION__)
 #elif defined(__INTEL_COMPILER)
 static_assert(__INTEL_COMPILER >= 1900);
 #define WLL_CURRENT_FUNCTION std::string(__FUNCTION__)
-#elif defined(__clang__)
-static_assert(__clang_major__ >= 4);
-#define WLL_CURRENT_FUNCTION std::string(__PRETTY_FUNCTION__)
 #elif defined(_MSC_VER)
 static_assert(_MSC_VER >= 1911);
 #define WLL_CURRENT_FUNCTION std::string(__FUNCSIG__)

--- a/include/wll_interface.h
+++ b/include/wll_interface.h
@@ -27,16 +27,18 @@
 namespace wll
 {
 
-
-#if defined(__GNUC__) || defined(__clang__)
-static_assert(__GNUC__ >= 7 || __clang_major__ >= 4);
-#define WLL_CURRENT_FUNCTION std::string(__PRETTY_FUNCTION__)
-#elif defined(__INTEL_COMPILER)
-static_assert(__INTEL_COMPILER >= 1900);
-#define WLL_CURRENT_FUNCTION std::string(__FUNCTION__)
-#elif defined(_MSC_VER)
-static_assert(_MSC_VER >= 1911);
-#define WLL_CURRENT_FUNCTION std::string(__FUNCSIG__)
+#if defined(__clang__)                                                               
+static_assert(__clang_major__ >= 4);                                                 
+#define WLL_CURRENT_FUNCTION std::string(__PRETTY_FUNCTION__)                        
+#elif defined(__GNUC__)                                                              
+static_assert(__GNUC__ >= 7);                                                        
+#define WLL_CURRENT_FUNCTION std::string(__PRETTY_FUNCTION__)                        
+#elif defined(__INTEL_COMPILER)                                                      
+static_assert(__INTEL_COMPILER >= 1900);                                             
+#define WLL_CURRENT_FUNCTION std::string(__FUNCTION__)                               
+#elif defined(_MSC_VER)                                                              
+static_assert(_MSC_VER >= 1911);                                                     
+#define WLL_CURRENT_FUNCTION std::string(__FUNCSIG__)                                
 #endif
 
 static_assert(sizeof(mint) == sizeof(size_t));


### PR DESCRIPTION
First of all: thanks for writing this! I've been interested in adding Mathematica bindings to a C++ library of mine for a while, and this project has been incredibly helpful.

On my mac, Apple clang 14.0.3 seems to define `__GNUC__` with some weird value that makes it fail the `static_assert`ion here https://github.com/njpipeorgan/wll-interface/blob/82e871944a981b8f03a30a0c302ec0e29a9e9698/include/wll_interface.h#L31-L33

So this PR just rearranges the conditionals a bit to make it the `__clang__` check come first to avoid this problem. It's been tested on a mac with Apple Clang 14.0.3, and on an Ubuntu machine with gcc (10, 11, 12) and clang (11 - 16).
